### PR TITLE
Update the armv7 cross.txt

### DIFF
--- a/cross.txt
+++ b/cross.txt
@@ -2,7 +2,7 @@
 system = 'windows'
 cpu_family = 'armv7'
 cpu = 'arm'
-endian = 'big'
+endian = 'little'
 
 
 [binaries]


### PR DESCRIPTION
cross script was incorrectly set to compile big endian ARM code even though Windows RT 8.1/10 ARM32 is little endian